### PR TITLE
adds github actions workflow to deploy to public ecr

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,9 +16,17 @@ jobs:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions
           role-session-name: GitHubActions-${{ github.run_id }}
-      - name: Build, tag, and push image to Amazon ECR
+      - name: Build, tag, and push default image to Amazon ECR
         run: |
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/s5e9c0e3
+          cd default
           docker build -t ci:${{ github.ref_name }} .
           docker tag ci:${{ github.ref_name }} public.ecr.aws/s5e9c0e3/ci:${{ github.ref_name }}
           docker push public.ecr.aws/s5e9c0e3/ci:${{ github.ref_name }}
+      - name: Build, tag, and push serverless image to Amazon ECR
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/s5e9c0e3
+          cd serverless
+          docker build -t ci:${{ github.ref_name }}-serverless .
+          docker tag ci:${{ github.ref_name }}-serverless public.ecr.aws/s5e9c0e3/ci:${{ github.ref_name }}-serverless
+          docker push public.ecr.aws/s5e9c0e3/ci:${{ github.ref_name }}-serverless

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,24 @@
+name: publish-image
+on:
+  push:
+    tags: '*'
+jobs:
+  publish-tagged-image:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - name: Assume role
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions
+          role-session-name: GitHubActions-${{ github.run_id }}
+      - name: Build, tag, and push image to Amazon ECR
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/s5e9c0e3
+          docker build -t ci:${{ github.ref_name }} .
+          docker tag ci:${{ github.ref_name }} public.ecr.aws/s5e9c0e3/ci:${{ github.ref_name }}
+          docker push public.ecr.aws/s5e9c0e3/ci:${{ github.ref_name }}


### PR DESCRIPTION
To deploy/create an image tag, push a tag to the repository (serverless will automatically receive the `-serverless` suffix)

Repository will be hosted here: https://gallery.ecr.aws/s5e9c0e3/ci (soon to be https://gallery.ecr.aws/trek10/ci)